### PR TITLE
Fix bower.json, broken json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "*.js",
     "*.png",
     "*.json",
-    "*.html"
+    "*.html",
     "node_modules/",
     "bower_components/",
     "test/",


### PR DESCRIPTION
Tiny json syntax fix.

Fixes [bower](http://bower.io/) so it doesn't exit with an error.