### PR TITLE
Allow running in environment without the global window variable

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -1343,7 +1343,7 @@ var nomnoml = nomnoml || {};
 
 	nomnoml.draw = function (canvas, code, scale) {
 		var skCanvas = skanaar.Canvas(canvas)
-		var superSampling = window.devicePixelRatio || 1
+		var superSampling = typeof window !== 'undefined' && window.devicePixelRatio || 1
 		return parseAndRender(code, skCanvas, canvas, superSampling, scale || 1)
 	};
 })();

--- a/nomnoml.app.js
+++ b/nomnoml.app.js
@@ -200,7 +200,7 @@ $(function (){
 		try {
 			lineMarker.css('top', -30)
 			lineNumbers.toggleClass('error', false)
-			var superSampling = window.devicePixelRatio || 1
+			var superSampling = typeof window !== 'undefined' && window.devicePixelRatio || 1
 			var scale = superSampling * Math.exp(zoomLevel/10)
 
 			var model = nomnoml.draw(canvasElement, currentText(), scale)


### PR DESCRIPTION
Prepare for usage in NodeJS with the node-canvas module.

A part of the suggested fix for the issue #29.