### PR TITLE
renderSVG now sets width/height based on the measurer.

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -212,6 +212,8 @@ skanaar.vector = {
     rot: function (a){ return { x: a.y, y: -a.x } }
 };
 ;
+var lodash = require('lodash');
+
 var skanaar = skanaar || {}
 skanaar.Svg = function (globalStyle){
 	var initialState = { x: 0, y: 0, stroke: 'none', fill: 'none', textAlign: 'left' }
@@ -279,7 +281,7 @@ skanaar.Svg = function (globalStyle){
 		background: function (/*r, g, b*/){},
 		clear: function (){},
 		circle: function (x, y, r){
-			var attr = (arguments.length === 2) ? 
+			var attr = (arguments.length === 2) ?
 					{r: y, cx: tX(x.x), cy: tY(x.y)} :
 					{r: r, cx: tX(x),   cy: tY(y)}
 			var element = Element('circle', attr)
@@ -358,27 +360,28 @@ skanaar.Svg = function (globalStyle){
 			last(states).x += dx
 			last(states).y += dy
 		},
-		serialize: function (){
-			function toAttr(obj){
-				function toKeyValue(key){ return key + '="' + obj[key] + '"' }
-				return Object.keys(obj).map(toKeyValue).join(' ')
-			}
-			function toHtml(e){
-				return '<'+e.name+' '+toAttr(e.attr)+'>'+(e.content || '')+'</'+e.name+'>'
-			}
-			var attrs = {
-				version: '1.1',
-				baseProfile: 'full',
-				width: '100%',
-				height: '100%',
-				xmlns: 'http://www.w3.org/2000/svg',
-				'xmlns:xlink': 'http://www.w3.org/1999/xlink', 
-				'xmlns:ev': 'http://www.w3.org/2001/xml-events',
-				style: lastDefined('font') + ';' + globalStyle
-			}
-			var innerSvg = elements.map(toHtml).join('\n')
-			return toHtml(Element('svg', attrs, innerSvg))
-		}
+    serialize: function (_attributes){
+      var attrs = attributes || {};
+      attrs.version = attrs.version || '1.1';
+      attrs.baseProfile = attrs.baseProfile || 'full';
+      attrs.width = attrs.width || '100%';
+      attrs.height = attrs.height || '100%';
+      attrs.xmlns = attrs.xmlns || 'http://www.w3.org/2000/svg';
+      attrs['xmlns:xlink'] = attrs['xmlns:xlink'] || 'http://www.w3.org/1999/xlink';
+      attrs['xmlns:ev']  = attrs['xmlns:ev'] || 'http://www.w3.org/2001/xml-events';
+      attrs.style = attrs.style || lastDefined('font') + ';' + globalStyle;
+
+      function toAttr(obj){
+        function toKeyValue(key){ return key + '="' + obj[key] + '"' }
+        return Object.keys(obj).map(toKeyValue).join(' ')
+      }
+      function toHtml(e){
+        return '<'+e.name+' '+toAttr(e.attr)+'>'+(e.content || '')+'</'+e.name+'>'
+
+      }
+      var innerSvg = elements.map(toHtml).join('\n')
+      return toHtml(Element('svg', attrs, innerSvg))
+    }
 	}
 };
 ;
@@ -1602,7 +1605,10 @@ var nomnoml = nomnoml || {};
 		};
 		var layout = nomnoml.layout(measurer, config, ast)
 		nomnoml.render(skCanvas, config, layout, measurer.setFont)
-		return skCanvas.serialize()
+		return skCanvas.serialize({
+		  width: layout.width,
+		  height: layout.height
+		})
 	};
 })();
 ;

--- a/nomnoml.js
+++ b/nomnoml.js
@@ -91,6 +91,9 @@ var nomnoml = nomnoml || {};
 		};
 		var layout = nomnoml.layout(measurer, config, ast)
 		nomnoml.render(skCanvas, config, layout, measurer.setFont)
-		return skCanvas.serialize()
+		return skCanvas.serialize({
+		  width: layout.width,
+		  height: layout.height
+		})
 	};
 })();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "jison": "0.4.13"
   },
   "scripts": {
-    "prepublish": "node build.js",
+    "build": "node build",
+    "prepublish": "node build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "directories": {

--- a/skanaar.svg.js
+++ b/skanaar.svg.js
@@ -65,7 +65,7 @@ skanaar.Svg = function (globalStyle){
 		background: function (/*r, g, b*/){},
 		clear: function (){},
 		circle: function (x, y, r){
-			var attr = (arguments.length === 2) ? 
+			var attr = (arguments.length === 2) ?
 					{r: y, cx: tX(x.x), cy: tY(x.y)} :
 					{r: r, cx: tX(x),   cy: tY(y)}
 			var element = Element('circle', attr)
@@ -144,26 +144,27 @@ skanaar.Svg = function (globalStyle){
 			last(states).x += dx
 			last(states).y += dy
 		},
-		serialize: function (){
-			function toAttr(obj){
-				function toKeyValue(key){ return key + '="' + obj[key] + '"' }
-				return Object.keys(obj).map(toKeyValue).join(' ')
-			}
-			function toHtml(e){
-				return '<'+e.name+' '+toAttr(e.attr)+'>'+(e.content || '')+'</'+e.name+'>'
-			}
-			var attrs = {
-				version: '1.1',
-				baseProfile: 'full',
-				width: '100%',
-				height: '100%',
-				xmlns: 'http://www.w3.org/2000/svg',
-				'xmlns:xlink': 'http://www.w3.org/1999/xlink', 
-				'xmlns:ev': 'http://www.w3.org/2001/xml-events',
-				style: lastDefined('font') + ';' + globalStyle
-			}
-			var innerSvg = elements.map(toHtml).join('\n')
-			return toHtml(Element('svg', attrs, innerSvg))
-		}
+    serialize: function (_attributes){
+      var attrs = attributes || {};
+      attrs.version = attrs.version || '1.1';
+      attrs.baseProfile = attrs.baseProfile || 'full';
+      attrs.width = attrs.width || '100%';
+      attrs.height = attrs.height || '100%';
+      attrs.xmlns = attrs.xmlns || 'http://www.w3.org/2000/svg';
+      attrs['xmlns:xlink'] = attrs['xmlns:xlink'] || 'http://www.w3.org/1999/xlink';
+      attrs['xmlns:ev']  = attrs['xmlns:ev'] || 'http://www.w3.org/2001/xml-events';
+      attrs.style = attrs.style || lastDefined('font') + ';' + globalStyle;
+
+      function toAttr(obj){
+        function toKeyValue(key){ return key + '="' + obj[key] + '"' }
+        return Object.keys(obj).map(toKeyValue).join(' ')
+      }
+      function toHtml(e){
+        return '<'+e.name+' '+toAttr(e.attr)+'>'+(e.content || '')+'</'+e.name+'>'
+
+      }
+      var innerSvg = elements.map(toHtml).join('\n')
+      return toHtml(Element('svg', attrs, innerSvg))
+    }
 	}
 };


### PR DESCRIPTION
This ensures the SVG takes up the appropriate horizontal and vertical space within a document.

---

An existing test appears to be failing (and was before this change).