### PR TITLE
Improved label placement and multiline labels

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -462,8 +462,7 @@ yy: {},
 symbols_: {"error":2,"root":3,"compartment":4,"EOF":5,"slot":6,"IDENT":7,"class":8,"association":9,"SEP":10,"parts":11,"|":12,"[":13,"]":14,"$accept":0,"$end":1},
 terminals_: {2:"error",5:"EOF",7:"IDENT",10:"SEP",12:"|",13:"[",14:"]"},
 productions_: [0,[3,2],[6,1],[6,1],[6,1],[4,1],[4,3],[11,1],[11,3],[11,2],[9,3],[8,3]],
-performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
-/**/) {
+performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -968,8 +967,7 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
-/**/) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {
@@ -1417,10 +1415,58 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 
 	var empty = false, filled = true, diamond = true
 
+    function renderLabel(text, refPoint, quadrant){
+		if (text) {
+			var fontSize = config.fontSize
+			var lines = text.split("`")
+			var area = {
+				width : _.max(_.map(lines, function(l){ return g.measureText(l).width })),
+				height : fontSize*lines.length
+			}
+			var origin = {
+				x: (quadrant === 1) || (quadrant === 4) ? refPoint.x + padding : refPoint.x - area.width - padding,
+				y: (quadrant === 3) || (quadrant === 4) ? refPoint.y + padding : refPoint.y - area.height - padding
+			}
+			_.each(lines, function(l, i){ g.fillText(l, origin.x, origin.y + fontSize*(i+1)) })
+		}
+	}
+
+	// find basic quadrant using relative position of endpoint and block rectangle
+	function findLabelQuadrant(point, rect, def) {
+		if (point.x < rect.x && point.y < rect.y-rect.height/2) return 1;
+		if (point.y > rect.y && point.x > rect.x+rect.width/2) return 1;
+		
+		if (point.x > rect.x && point.y < rect.y-rect.height/2) return 2;
+		if (point.y > rect.y && point.x < rect.x-rect.width/2) return 2;
+
+		if (point.x > rect.x && point.y > rect.y+rect.height/2) return 3;
+		if (point.y < rect.y && point.x < rect.x-rect.width/2) return 3;
+
+		if (point.x < rect.x && point.y > rect.y+rect.height/2) return 4;
+		if (point.y < rect.y && point.x > rect.x+rect.width/2) return 4;
+
+		return def;
+	}
+
+	// Flip basic label quadrant if needed, to avoid crossing a bent relationship line
+	function adjustLabelQuadrant(quadrant, point, opposite) {
+		if ((opposite.x == point.x) || (opposite.y == point.y)) return quadrant;
+		var flipHorizontally = [4, 3, 2, 1]
+		var flipVertically = [2, 1, 4, 3]
+		var oppositeQuadrant = (opposite.y < point.y) ?
+							((opposite.x < point.x) ? 2 : 1) :
+							((opposite.x < point.x) ? 3 : 4);
+		// if an opposite relation end is in the same quadrant as a label, we need to flip the label
+		if (oppositeQuadrant === quadrant) {
+			if (config.direction === "LR") return flipHorizontally[quadrant-1];
+			if (config.direction === "TD") return flipVertically[quadrant-1];
+		}
+		return quadrant; 	
+	}
+
 	function renderRelation(r, compartment){
 		var startNode = _.findWhere(compartment.nodes, {name:r.start})
 		var endNode = _.findWhere(compartment.nodes, {name:r.end})
-
 		var start = rectIntersection(r.path[1], _.first(r.path), startNode)
 		var end = rectIntersection(r.path[r.path.length-2], _.last(r.path), endNode)
 
@@ -1429,10 +1475,9 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 
 		g.fillStyle(config.stroke)
 		setFont(config, 'normal')
-		var textW = g.measureText(r.endLabel).width
-		var labelX = config.direction === 'LR' ? -padding-textW : padding
-		if (r.startLabel) g.fillText(r.startLabel, start.x+padding, start.y+padding+fontSize)
-		if (r.endLabel)	 g.fillText(r.endLabel, end.x+labelX, end.y-padding)
+
+		renderLabel(r.startLabel, start, adjustLabelQuadrant(findLabelQuadrant(start, startNode, 4), start, end))
+		renderLabel(r.endLabel, end, adjustLabelQuadrant(findLabelQuadrant(end, endNode, 2), end, start))
 
 		if (r.assoc !== '-/-'){
 			if (g.setLineDash && skanaar.hasSubstring(r.assoc, '--')){

--- a/nomnoml.jison.js
+++ b/nomnoml.jison.js
@@ -77,8 +77,7 @@ yy: {},
 symbols_: {"error":2,"root":3,"compartment":4,"EOF":5,"slot":6,"IDENT":7,"class":8,"association":9,"SEP":10,"parts":11,"|":12,"[":13,"]":14,"$accept":0,"$end":1},
 terminals_: {2:"error",5:"EOF",7:"IDENT",10:"SEP",12:"|",13:"[",14:"]"},
 productions_: [0,[3,2],[6,1],[6,1],[6,1],[4,1],[4,3],[11,1],[11,3],[11,2],[9,3],[8,3]],
-performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
-/**/) {
+performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -583,8 +582,7 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
-/**/) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {

--- a/nomnoml.renderer.js
+++ b/nomnoml.renderer.js
@@ -86,10 +86,58 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 
 	var empty = false, filled = true, diamond = true
 
+    function renderLabel(text, refPoint, quadrant){
+		if (text) {
+			var fontSize = config.fontSize
+			var lines = text.split("`")
+			var area = {
+				width : _.max(_.map(lines, function(l){ return g.measureText(l).width })),
+				height : fontSize*lines.length
+			}
+			var origin = {
+				x: (quadrant === 1) || (quadrant === 4) ? refPoint.x + padding : refPoint.x - area.width - padding,
+				y: (quadrant === 3) || (quadrant === 4) ? refPoint.y + padding : refPoint.y - area.height - padding
+			}
+			_.each(lines, function(l, i){ g.fillText(l, origin.x, origin.y + fontSize*(i+1)) })
+		}
+	}
+
+	// find basic quadrant using relative position of endpoint and block rectangle
+	function findLabelQuadrant(point, rect, def) {
+		if (point.x < rect.x && point.y < rect.y-rect.height/2) return 1;
+		if (point.y > rect.y && point.x > rect.x+rect.width/2) return 1;
+		
+		if (point.x > rect.x && point.y < rect.y-rect.height/2) return 2;
+		if (point.y > rect.y && point.x < rect.x-rect.width/2) return 2;
+
+		if (point.x > rect.x && point.y > rect.y+rect.height/2) return 3;
+		if (point.y < rect.y && point.x < rect.x-rect.width/2) return 3;
+
+		if (point.x < rect.x && point.y > rect.y+rect.height/2) return 4;
+		if (point.y < rect.y && point.x > rect.x+rect.width/2) return 4;
+
+		return def;
+	}
+
+	// Flip basic label quadrant if needed, to avoid crossing a bent relationship line
+	function adjustLabelQuadrant(quadrant, point, opposite) {
+		if ((opposite.x == point.x) || (opposite.y == point.y)) return quadrant;
+		var flipHorizontally = [4, 3, 2, 1]
+		var flipVertically = [2, 1, 4, 3]
+		var oppositeQuadrant = (opposite.y < point.y) ?
+							((opposite.x < point.x) ? 2 : 1) :
+							((opposite.x < point.x) ? 3 : 4);
+		// if an opposite relation end is in the same quadrant as a label, we need to flip the label
+		if (oppositeQuadrant === quadrant) {
+			if (config.direction === "LR") return flipHorizontally[quadrant-1];
+			if (config.direction === "TD") return flipVertically[quadrant-1];
+		}
+		return quadrant; 	
+	}
+
 	function renderRelation(r, compartment){
 		var startNode = _.findWhere(compartment.nodes, {name:r.start})
 		var endNode = _.findWhere(compartment.nodes, {name:r.end})
-
 		var start = rectIntersection(r.path[1], _.first(r.path), startNode)
 		var end = rectIntersection(r.path[r.path.length-2], _.last(r.path), endNode)
 
@@ -98,10 +146,9 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 
 		g.fillStyle(config.stroke)
 		setFont(config, 'normal')
-		var textW = g.measureText(r.endLabel).width
-		var labelX = config.direction === 'LR' ? -padding-textW : padding
-		if (r.startLabel) _.each(r.startLabel.split("`"), function(t, i){ g.fillText(t, start.x+padding, start.y+padding+fontSize*(i+1)) })
-		if (r.endLabel)	 _.each(r.endLabel.split("`"), function(t, i){ g.fillText(t, end.x+labelX, end.y-padding+fontSize*i) })
+
+		renderLabel(r.startLabel, start, adjustLabelQuadrant(findLabelQuadrant(start, startNode, 4), start, end))
+		renderLabel(r.endLabel, end, adjustLabelQuadrant(findLabelQuadrant(end, endNode, 2), end, start))
 
 		if (r.assoc !== '-/-'){
 			if (g.setLineDash && skanaar.hasSubstring(r.assoc, '--')){

--- a/nomnoml.renderer.js
+++ b/nomnoml.renderer.js
@@ -100,8 +100,8 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 		setFont(config, 'normal')
 		var textW = g.measureText(r.endLabel).width
 		var labelX = config.direction === 'LR' ? -padding-textW : padding
-		if (r.startLabel) g.fillText(r.startLabel, start.x+padding, start.y+padding+fontSize)
-		if (r.endLabel)	 g.fillText(r.endLabel, end.x+labelX, end.y-padding)
+		if (r.startLabel) _.each(r.startLabel.split("`"), function(t, i){ g.fillText(t, start.x+padding, start.y+padding+fontSize*(i+1)) })
+		if (r.endLabel)	 _.each(r.endLabel.split("`"), function(t, i){ g.fillText(t, end.x+labelX, end.y-padding+fontSize*i) })
 
 		if (r.assoc !== '-/-'){
 			if (g.setLineDash && skanaar.hasSubstring(r.assoc, '--')){

--- a/test/label-placement.usecase.html
+++ b/test/label-placement.usecase.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>test label placement</title>
+  <link rel="shortcut icon" type="image/png" href="favicon.png">
+  <script src="../lib/lodash.min.js"></script>
+  <script src="../lib/dagre.min.js"></script>
+  <script src="../dist/nomnoml.js"></script>
+</head>
+<body>
+    <script id="noml" type="text/plain">
+        #direction: right
+        #padding: 0
+        #arrowSize: 0.2
+        #spacing: 120
+        #edgeMargin: 5
+        #lineWidth: 2
+        #leading: 3
+        #fontSize: 12
+        #bendSize: 0.4
+        
+        [Right|
+        [Top] <-> [Down]
+        ]
+        [Left|
+        [Top] <-> [Down]
+        ]
+        
+        [Left] left`association <-> right`association [Central 1]
+        [Left] left`association <-> right`association [Central 2]
+        [Left] left`association <-> right`association [Central 3]
+        
+        [Central 1] left`association <-> right`association [Right]
+        [Central 2] left`association <-> right`association [Right]
+        [Central 3] left`association <-> right`association [Right]
+        
+        [Central 1] self <-> [Central 1]     
+    </script>
+    <canvas id="target-canvas"></canvas>
+    <script>
+        var canvas = document.getElementById('target-canvas');
+        var noml = document.getElementById('noml').innerHTML;
+        nomnoml.draw(canvas, noml);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This change improves an association label placement algorithm, avoiding overlapping with connecting blocks and with own association lines. See ./test/label-placement.usecase.html for a usecase. Should fix an issue #28 

Also added possibility to create multi-line association labels, using backticks (`) as line delimiters.