### PR TITLE
Adds a "transceiver" visual combining "receiver" and "sender" in one stereotype

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This is how the Decorator pattern looks like in nomnoml syntax:
     [<input> name]
     [<sender> name]
     [<receiver> name]
+    [<transceiver> name]
     [<actor> name]
     [<usecase> name]
     [<label> name]
@@ -162,6 +163,7 @@ Available visuals are
     visual=roundrect
     visual=sender
     visual=start
+    visual=transceiver
 
 Available modifiers are
 

--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -1118,7 +1118,7 @@ nomnoml.styles = {
   SENDER:   { center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'sender' },
   START:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 1, hull: 'icon', visual: 'start' },
   STATE:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'roundrect' },
-  TRANSIVER:{ center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'transiver' },
+  TRANSCEIVER:{ center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'transceiver' },
   USECASE:  { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'ellipse' },
 }
 
@@ -1232,7 +1232,7 @@ nomnoml.visualizers = {
     g.fillStyle(config.stroke)
     g.circle(node.x, y+node.height/2, node.height/2.5).fill()
   },
-  transiver : function (node, x, y, padding, config, g) {
+  transceiver : function (node, x, y, padding, config, g) {
       g.circuit([
         {x: x-padding, y: y},
         {x: x+node.width, y: y},

--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -462,8 +462,7 @@ yy: {},
 symbols_: {"error":2,"root":3,"compartment":4,"EOF":5,"slot":6,"IDENT":7,"class":8,"association":9,"SEP":10,"parts":11,"|":12,"[":13,"]":14,"$accept":0,"$end":1},
 terminals_: {2:"error",5:"EOF",7:"IDENT",10:"SEP",12:"|",13:"[",14:"]"},
 productions_: [0,[3,2],[6,1],[6,1],[6,1],[4,1],[4,3],[11,1],[11,3],[11,2],[9,3],[8,3]],
-performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
-/**/) {
+performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -968,8 +967,7 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
-/**/) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {
@@ -1120,6 +1118,7 @@ nomnoml.styles = {
   SENDER:   { center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'sender' },
   START:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 1, hull: 'icon', visual: 'start' },
   STATE:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'roundrect' },
+  TRANSIVER:{ center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'transiver' },
   USECASE:  { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'ellipse' },
 }
 
@@ -1200,13 +1199,13 @@ nomnoml.visualizers = {
     ]).fillAndStroke()
   },
   receiver : function (node, x, y, padding, config, g) {
-    g.circuit([
-      {x: x, y: y},
-      {x: x+node.width+padding, y: y},
-      {x: x+node.width-padding, y: y+node.height/2},
-      {x: x+node.width+padding, y: y+node.height},
-      {x: x, y: y+node.height}
-    ]).fillAndStroke()
+      g.circuit([
+        {x: x-padding, y: y},
+        {x: x+node.width, y: y},
+        {x: x+node.width, y: y+node.height},
+        {x: x-padding, y: y+node.height},
+        {x: x, y: y+node.height/2},
+      ]).fillAndStroke()
   },
   rhomb : function (node, x, y, padding, config, g) {
     g.circuit([
@@ -1221,17 +1220,27 @@ nomnoml.visualizers = {
     g.roundRect(x, y, node.width, node.height, r).fillAndStroke()
   },
   sender : function (node, x, y, padding, config, g) {
-    g.circuit([
-      {x: x, y: y},
-      {x: x+node.width-padding, y: y},
-      {x: x+node.width+padding, y: y+node.height/2},
-      {x: x+node.width-padding, y: y+node.height},
-      {x: x, y: y+node.height}
-    ]).fillAndStroke()
+      g.circuit([
+        {x: x, y: y},
+        {x: x+node.width-padding, y: y},
+        {x: x+node.width, y: y+node.height/2},
+        {x: x+node.width-padding, y: y+node.height},
+        {x: x, y: y+node.height}
+      ]).fillAndStroke()
   },
   start : function (node, x, y, padding, config, g) {
     g.fillStyle(config.stroke)
     g.circle(node.x, y+node.height/2, node.height/2.5).fill()
+  },
+  transiver : function (node, x, y, padding, config, g) {
+      g.circuit([
+        {x: x-padding, y: y},
+        {x: x+node.width, y: y},
+        {x: x+node.width+padding, y: y+node.height/2},
+        {x: x+node.width, y: y+node.height},
+        {x: x-padding, y: y+node.height},
+        {x: x, y: y+node.height/2}
+      ]).fillAndStroke()
   },
 };
 var nomnoml = nomnoml || {}

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
 				[&lt;input&gt; name]<br>
 				[&lt;sender&gt; name]<br>
 				[&lt;receiver&gt; name]<br>
+				[&lt;transiver&gt; name]<br>
 				[&lt;actor&gt; name]<br>
 				[&lt;usecase&gt; name]<br>
 				[&lt;label&gt; name]<br>
@@ -103,8 +104,9 @@
 				visual=rhomb<br>
 				visual=roundrect<br>
 				visual=sender<br>
-				visual=start
-
+				visual=start<br>
+				visual=transiver
+				
 				<label>Available modifiers are</label>
 
 				center<br>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 				[&lt;input&gt; name]<br>
 				[&lt;sender&gt; name]<br>
 				[&lt;receiver&gt; name]<br>
-				[&lt;transiver&gt; name]<br>
+				[&lt;transceiver&gt; name]<br>
 				[&lt;actor&gt; name]<br>
 				[&lt;usecase&gt; name]<br>
 				[&lt;label&gt; name]<br>
@@ -105,7 +105,7 @@
 				visual=roundrect<br>
 				visual=sender<br>
 				visual=start<br>
-				visual=transiver
+				visual=transceiver
 				
 				<label>Available modifiers are</label>
 

--- a/nomnoml.jison.js
+++ b/nomnoml.jison.js
@@ -77,8 +77,7 @@ yy: {},
 symbols_: {"error":2,"root":3,"compartment":4,"EOF":5,"slot":6,"IDENT":7,"class":8,"association":9,"SEP":10,"parts":11,"|":12,"[":13,"]":14,"$accept":0,"$end":1},
 terminals_: {2:"error",5:"EOF",7:"IDENT",10:"SEP",12:"|",13:"[",14:"]"},
 productions_: [0,[3,2],[6,1],[6,1],[6,1],[4,1],[4,3],[11,1],[11,3],[11,2],[9,3],[8,3]],
-performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
-/**/) {
+performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -583,8 +582,7 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
-/**/) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {

--- a/nomnoml.visuals.js
+++ b/nomnoml.visuals.js
@@ -19,6 +19,7 @@ nomnoml.styles = {
   SENDER:   { center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'sender' },
   START:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 1, hull: 'icon', visual: 'start' },
   STATE:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'roundrect' },
+  TRANSIVER:{ center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'transiver' },
   USECASE:  { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'ellipse' },
 }
 
@@ -99,13 +100,13 @@ nomnoml.visualizers = {
     ]).fillAndStroke()
   },
   receiver : function (node, x, y, padding, config, g) {
-    g.circuit([
-      {x: x, y: y},
-      {x: x+node.width+padding, y: y},
-      {x: x+node.width-padding, y: y+node.height/2},
-      {x: x+node.width+padding, y: y+node.height},
-      {x: x, y: y+node.height}
-    ]).fillAndStroke()
+      g.circuit([
+        {x: x-padding, y: y},
+        {x: x+node.width, y: y},
+        {x: x+node.width, y: y+node.height},
+        {x: x-padding, y: y+node.height},
+        {x: x, y: y+node.height/2},
+      ]).fillAndStroke()
   },
   rhomb : function (node, x, y, padding, config, g) {
     g.circuit([
@@ -120,16 +121,26 @@ nomnoml.visualizers = {
     g.roundRect(x, y, node.width, node.height, r).fillAndStroke()
   },
   sender : function (node, x, y, padding, config, g) {
-    g.circuit([
-      {x: x, y: y},
-      {x: x+node.width-padding, y: y},
-      {x: x+node.width+padding, y: y+node.height/2},
-      {x: x+node.width-padding, y: y+node.height},
-      {x: x, y: y+node.height}
-    ]).fillAndStroke()
+      g.circuit([
+        {x: x, y: y},
+        {x: x+node.width-padding, y: y},
+        {x: x+node.width, y: y+node.height/2},
+        {x: x+node.width-padding, y: y+node.height},
+        {x: x, y: y+node.height}
+      ]).fillAndStroke()
   },
   start : function (node, x, y, padding, config, g) {
     g.fillStyle(config.stroke)
     g.circle(node.x, y+node.height/2, node.height/2.5).fill()
+  },
+  transiver : function (node, x, y, padding, config, g) {
+      g.circuit([
+        {x: x-padding, y: y},
+        {x: x+node.width, y: y},
+        {x: x+node.width+padding, y: y+node.height/2},
+        {x: x+node.width, y: y+node.height},
+        {x: x-padding, y: y+node.height},
+        {x: x, y: y+node.height/2}
+      ]).fillAndStroke()
   },
 }

--- a/nomnoml.visuals.js
+++ b/nomnoml.visuals.js
@@ -19,7 +19,7 @@ nomnoml.styles = {
   SENDER:   { center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'sender' },
   START:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 1, hull: 'icon', visual: 'start' },
   STATE:    { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'roundrect' },
-  TRANSIVER:{ center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'transiver' },
+  TRANSCEIVER:{ center: 0, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'transceiver' },
   USECASE:  { center: 1, bold: 0, underline: 0, italic: 0, dashed: 0, empty: 0, hull: 'auto', visual: 'ellipse' },
 }
 
@@ -133,7 +133,7 @@ nomnoml.visualizers = {
     g.fillStyle(config.stroke)
     g.circle(node.x, y+node.height/2, node.height/2.5).fill()
   },
-  transiver : function (node, x, y, padding, config, g) {
+  transceiver : function (node, x, y, padding, config, g) {
       g.circuit([
         {x: x-padding, y: y},
         {x: x+node.width, y: y},


### PR DESCRIPTION
This change adds a new "transceiver" visual combining "receiver" and "sender" in one stereotype.

Also it makes all three messaging visuals a bit more visually pleasing:
* the receiver's "wedge" is placed on the left (like the corresponding transciever's left edge) for uniformity and visual flow
* wedges are more moderate and do not cause visual off-balance