### PR TITLE
Added html escaping of the text and a viewbox attribute to the svg export

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -326,7 +326,7 @@ skanaar.Svg = function (globalStyle){
 		fillText: function (text, x, y){
 			if (lastDefined('textAlign') === 'center')
 				x -= this.measureText(text).width/2
-			return newElement('text', { x: tX(x), y: tY(y) }, text)
+			return newElement('text', { x: tX(x), y: tY(y) }, _.escape(text))
 		},
 		lineCap: function (cap){ globalStyle += ';stroke-linecap:'+cap },
 		lineJoin: function (join){ globalStyle += ';stroke-linejoin:'+join },
@@ -369,6 +369,9 @@ skanaar.Svg = function (globalStyle){
       attrs.baseProfile = attrs.baseProfile || 'full';
       attrs.width = attrs.width || '100%';
       attrs.height = attrs.height || '100%';
+      if(attrs.width !== '100%' && attrs.height != '100%') {
+        attrs.viewbox = '0 0 ' + attrs.width + ' ' + attrs.height;
+	  }
       attrs.xmlns = attrs.xmlns || 'http://www.w3.org/2000/svg';
       attrs['xmlns:xlink'] = attrs['xmlns:xlink'] || 'http://www.w3.org/1999/xlink';
       attrs['xmlns:ev']  = attrs['xmlns:ev'] || 'http://www.w3.org/2001/xml-events';
@@ -468,7 +471,7 @@ symbols_: {"error":2,"root":3,"compartment":4,"EOF":5,"slot":6,"IDENT":7,"class"
 terminals_: {2:"error",5:"EOF",7:"IDENT",10:"SEP",12:"|",13:"[",14:"]"},
 productions_: [0,[3,2],[6,1],[6,1],[6,1],[4,1],[4,3],[11,1],[11,3],[11,2],[9,3],[8,3]],
 performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
-/**/) {
+/*``*/) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -974,7 +977,7 @@ stateStackSize:function stateStackSize() {
     },
 options: {},
 performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
-/**/) {
+/*``*/) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {

--- a/nomnoml.jison.js
+++ b/nomnoml.jison.js
@@ -78,7 +78,7 @@ symbols_: {"error":2,"root":3,"compartment":4,"EOF":5,"slot":6,"IDENT":7,"class"
 terminals_: {2:"error",5:"EOF",7:"IDENT",10:"SEP",12:"|",13:"[",14:"]"},
 productions_: [0,[3,2],[6,1],[6,1],[6,1],[4,1],[4,3],[11,1],[11,3],[11,2],[9,3],[8,3]],
 performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
-/**/) {
+/*``*/) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -584,7 +584,7 @@ stateStackSize:function stateStackSize() {
     },
 options: {},
 performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
-/**/) {
+/*``*/) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "nomnoml",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "JSONSelect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
+      "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=",
+      "dev": true
+    },
+    "cjson": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.2.1.tgz",
+      "integrity": "sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+      "dev": true
+    },
+    "cp-data": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cp-data/-/cp-data-1.1.3.tgz",
+      "integrity": "sha1-twX2N5ktto834tSN5SWx1m3Vs3I="
+    },
+    "dagre": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.4.6.tgz",
+      "integrity": "sha1-Yiq6gUSwhYCzuQsJgWoICXkfMLA=",
+      "requires": {
+        "cp-data": "1.1.3",
+        "graphlib": "0.7.4"
+      }
+    },
+    "ebnf-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+      "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
+      "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
+      "dev": true,
+      "requires": {
+        "esprima": "~1.0.2",
+        "estraverse": "~0.0.4",
+        "source-map": ">= 0.1.2"
+      }
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
+      "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI=",
+      "dev": true
+    },
+    "graphlib": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-0.7.4.tgz",
+      "integrity": "sha1-QQJ+o4HD2wa7DBsL6TbXMoWe3ac=",
+      "requires": {
+        "cp-data": "1.1.3"
+      }
+    },
+    "jison": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.13.tgz",
+      "integrity": "sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=",
+      "dev": true,
+      "requires": {
+        "JSONSelect": "0.4.0",
+        "cjson": "~0.2.1",
+        "ebnf-parser": "~0.1.9",
+        "escodegen": "0.0.21",
+        "esprima": "1.0.x",
+        "jison-lex": "0.2.x",
+        "lex-parser": "~0.1.3",
+        "nomnom": "1.5.2"
+      }
+    },
+    "jison-lex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
+      "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4=",
+      "dev": true,
+      "requires": {
+        "lex-parser": "0.1.x",
+        "nomnom": "1.5.2"
+      }
+    },
+    "lex-parser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
+      "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+      "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU="
+    },
+    "nomnom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+      "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
+      "dev": true,
+      "requires": {
+        "colors": "0.5.x",
+        "underscore": "1.1.x"
+      }
+    },
+    "source-map": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.2.tgz",
+      "integrity": "sha512-NDJB/R2BS7YJG0tP9SbE4DKwKj1idLT5RJqfVYZ7dreFX7wulZT3xxVhbYKrQo9n0JkRptl51TrX/5VK3HodMA==",
+      "dev": true,
+      "optional": true
+    },
+    "underscore": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+      "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
+      "dev": true
+    }
+  }
+}

--- a/skanaar.svg.js
+++ b/skanaar.svg.js
@@ -112,7 +112,7 @@ skanaar.Svg = function (globalStyle){
 		fillText: function (text, x, y){
 			if (lastDefined('textAlign') === 'center')
 				x -= this.measureText(text).width/2
-			return newElement('text', { x: tX(x), y: tY(y) }, text)
+			return newElement('text', { x: tX(x), y: tY(y) }, _.escape(text))
 		},
 		lineCap: function (cap){ globalStyle += ';stroke-linecap:'+cap },
 		lineJoin: function (join){ globalStyle += ';stroke-linejoin:'+join },
@@ -155,6 +155,9 @@ skanaar.Svg = function (globalStyle){
       attrs.baseProfile = attrs.baseProfile || 'full';
       attrs.width = attrs.width || '100%';
       attrs.height = attrs.height || '100%';
+      if(attrs.width !== '100%' && attrs.height != '100%') {
+        attrs.viewbox = '0 0 ' + attrs.width + ' ' + attrs.height;
+	  }
       attrs.xmlns = attrs.xmlns || 'http://www.w3.org/2000/svg';
       attrs['xmlns:xlink'] = attrs['xmlns:xlink'] || 'http://www.w3.org/1999/xlink';
       attrs['xmlns:ev']  = attrs['xmlns:ev'] || 'http://www.w3.org/2001/xml-events';

--- a/test/standalone.svg.usecase.html
+++ b/test/standalone.svg.usecase.html
@@ -33,6 +33,7 @@
         [<abstract>OOO]<:--[Pirate]
         [<abstract>MMM]<:--[Pirate]
         [<abstract>WWW]<:--[Pirate]
+        [<abstract>ABC<T>]<:--[Pirate]
         [<abstract>漢字漢字]<:--[Pirate]
         [Pirate]- 0..7[mischief]
         [<database>jollyness]->[Pirate]


### PR DESCRIPTION
I've added html escaping of the text (using lodash escape) to support generics Class<T> in the svg export. Before this broke the svg because of the angle brackets.

I've further added the viewbox attribute to support scaling of the svg by overriding the width and the height.

I've checked all the tests and they all still work except for the requirejs usecase, but that usecase also doesn't work (dagre can't be found) before my changes.