### PR TITLE
Support SVG dashed lines

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -34,21 +34,14 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 		var x = Math.round(node.x-node.width/2)
 		var y = Math.round(node.y-node.height/2)
 		var style = config.styles[node.type] || nomnoml.styles.CLASS
-		var dash
 
 		g.fillStyle(style.fill || config.fill[level] || _.last(config.fill))
 		if (style.dashed){
-			dash = Math.max(4, 2*config.lineWidth)
-			if (g.isCanvas) {
-				g.setLineDash([dash, dash])
-			}
+			var dash = Math.max(4, 2*config.lineWidth)
+			g.setLineDash([dash, dash])
 		}
 		var drawNode = nomnoml.visualizers[style.visual] || nomnoml.visualizers.class
 		drawNode(node, x, y, padding, config, g)
-		if (style.dashed && !g.isCanvas) {
-			// For SVGs, we must create the element before calling setLineDash().
-			g.setLineDash([dash, dash])
-		}
 		g.setLineDash([])
 
 		var yDivider = (style.visual === 'actor' ? y + padding*3/4 : y)
@@ -159,14 +152,8 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 		if (r.assoc !== '-/-'){
 			if (skanaar.hasSubstring(r.assoc, '--')){
 				var dash = Math.max(4, 2*config.lineWidth)
-				if (g.isCanvas) {
-					g.setLineDash([dash, dash])
-					strokePath(path)
-				} else {
-					// For SVGs, we must create the element before calling setLineDash()
-					strokePath(path)
-					g.setLineDash([dash, dash])
-				}
+				g.setLineDash([dash, dash])
+				strokePath(path)
 				g.setLineDash([])
 			}
 			else

--- a/src/skanaar.canvas.js
+++ b/src/skanaar.canvas.js
@@ -60,6 +60,7 @@ skanaar.Canvas = function (canvas, callbacks){
 	}
 
 	return {
+		isCanvas: true,
 		mousePos: function (){ return mousePos },
 		width: function (){ return canvas.width },
 		height: function (){ return canvas.height },

--- a/src/skanaar.canvas.js
+++ b/src/skanaar.canvas.js
@@ -60,7 +60,6 @@ skanaar.Canvas = function (canvas, callbacks){
 	}
 
 	return {
-		isCanvas: true,
 		mousePos: function (){ return mousePos },
 		width: function (){ return canvas.width },
 		height: function (){ return canvas.height },

--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -11,7 +11,8 @@ skanaar.Svg = function (globalStyle){
 			attr: attr,
 			content: content || undefined,
 			stroke: function (){
-				this.attr.style += 'stroke:'+lastDefined('stroke')+';fill:none;';
+				this.attr.style += 'stroke:'+lastDefined('stroke')+
+				  ';fill:none;stroke-dasharray:' + lastDefined('dashArray') + ';';
 				return this
 			},
 			fill: function (){
@@ -19,7 +20,8 @@ skanaar.Svg = function (globalStyle){
 				return this
 			},
 			fillAndStroke: function (){
-				this.attr.style += 'stroke:'+lastDefined('stroke')+';fill:'+lastDefined('fill')+';';
+				this.attr.style += 'stroke:'+lastDefined('stroke')+';fill:'+lastDefined('fill')+
+				  ';stroke-dasharray:' + lastDefined('dashArray') + ';';
 				return this
 			}
 		}
@@ -60,7 +62,6 @@ skanaar.Svg = function (globalStyle){
 	}
 
 	return {
-		isCanvas: false,
 		width: function (){ return elements.width },
 		height: function (){ return elements.height },
 		background: function (/*r, g, b*/){},
@@ -139,11 +140,8 @@ skanaar.Svg = function (globalStyle){
 			states.push(State(0, 0))
 		},
 		scale: function (){},
-		setLineDash: function (dashArray){
-			if (dashArray.length > 0) {
-				last(elements).attr.style = last(elements).attr.style +
-				    'stroke-dasharray:' + dashArray[0] + ' ' + dashArray[1] + ';'
-			}
+		setLineDash: function (d){
+			last(states).dashArray = (d.length === 0) ? 'none' : d[0] + ' ' + d[1]
 		},
 		stroke: function (){
 			last(elements).stroke()

--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -60,6 +60,7 @@ skanaar.Svg = function (globalStyle){
 	}
 
 	return {
+		isCanvas: false,
 		width: function (){ return elements.width },
 		height: function (){ return elements.height },
 		background: function (/*r, g, b*/){},
@@ -138,7 +139,12 @@ skanaar.Svg = function (globalStyle){
 			states.push(State(0, 0))
 		},
 		scale: function (){},
-		setLineDash: function (){},
+		setLineDash: function (dashArray){
+			if (dashArray.length > 0) {
+				last(elements).attr.style = last(elements).attr.style +
+				    'stroke-dasharray:' + dashArray[0] + ' ' + dashArray[1] + ';'
+			}
+		},
 		stroke: function (){
 			last(elements).stroke()
 		},


### PR DESCRIPTION
This PR amends `nomnoml` SVG output and adds a `stroke-dasharray` attribute when the input calls for a "dashed" element.