### PR TITLE
Improve SVG measureText

### DIFF
--- a/src/nomnoml.js
+++ b/src/nomnoml.js
@@ -80,10 +80,11 @@ var nomnoml = nomnoml || {};
 		return parseAndRender(code, skanaar.Canvas(canvas), canvas, scale || 1)
 	};
 
-	nomnoml.renderSvg = function (code) {
+	nomnoml.renderSvg = function (code, docCanvas) {
+		docCanvas = docCanvas || 0   // optional parameter
 		var ast = nomnoml.parse(code)
 		var config = getConfig(ast.directives)
-		var skCanvas = skanaar.Svg('')
+		var skCanvas = skanaar.Svg('', docCanvas)
 		function setFont(config, isBold, isItalic) {
 			var style = (isBold === 'bold' ? 'bold' : '')
 			if (isItalic) style = 'italic ' + style

--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -1,8 +1,17 @@
 var skanaar = skanaar || {}
-skanaar.Svg = function (globalStyle){
-	var initialState = { x: 0, y: 0, stroke: 'none', fill: 'none', textAlign: 'left' }
+skanaar.Svg = function (globalStyle, canvas){
+	var initialState = {
+		x: 0,
+		y: 0,
+		stroke: 'none',
+		dashArray: 'none',
+		fill: 'none',
+		textAlign: 'left'
+	}
 	var states = [initialState]
 	var elements = []
+	canvas = canvas || 0   // optional parameter
+	var ctx = canvas ? canvas.getContext('2d') : null
 
 	function Element(name, attr, content) {
 		attr.style = attr.style || ''
@@ -131,6 +140,26 @@ skanaar.Svg = function (globalStyle){
 		},
 		lineWidth: function (w){ globalStyle += ';stroke-width:'+w},
 		measureText: function (s){
+			var canUseCanvas = false
+			var fontStr = ''
+			var primaryFont = ''
+			if (ctx) {
+				fontStr = lastDefined('font')
+				var family = fontStr.replace(/^.*family:/, '')
+				primaryFont = family.replace(/[, ].*$/, '')
+				canUseCanvas = /Arial|Helvetica|Times/.test(primaryFont)
+				if (/Arial Black/.test(primaryFont)) canUseCanvas = false
+			}
+			if (canUseCanvas) {
+				var font = (/\bitalic\b/.test(fontStr) ? 'italic' : 'normal') + ' normal '
+				font += /\bbold\b/.test(fontStr) ? 'bold ' : 'normal '
+				var fontSize = fontStr.replace(/^.*font-size:/, '')
+				font += fontSize.replace(/;.*$/, '') + ' '
+				font += primaryFont + ', '
+				font += /Arial|Helvetica/.test(primaryFont) ? 'sans-serif' : 'serif'
+				ctx.font = font
+				return ctx.measureText(s)
+			}
 			return {
 				width: skanaar.sum(s, function (c){
 					if (c === 'M' || c === 'W') { return 14 }

--- a/test/index.html
+++ b/test/index.html
@@ -53,6 +53,7 @@
   </script>
   <script id="sample_source" type="text/plain">
       #zoom: 0.5
+      #font: Arial
       [Pirate|
           [beard]--[parrot]
           [beard]-:>[foul mouth]
@@ -103,7 +104,8 @@
       function script(id){ return document.getElementById(id).innerHTML }
       nomnoml.draw(elem('canvas1'), script('sample_source'))
       nomnoml.draw(elem('canvas2'), script('label_test_source'))
-      elem('svg-host').innerHTML = nomnoml.renderSvg(script('sample_source'))
+      elem('svg-host').innerHTML = nomnoml.renderSvg(script('sample_source'),
+          document.createElement('canvas'))
   </script>
 
 </body>


### PR DESCRIPTION
This PR aims to improve SVG node sizing when possible, by improving the accuracy of the SVG `measureText` method.  The function `renderSvg(code, canvas)`  now has an optional parameter `canvas`.

The pre-existing `measureText` heuristic is still in place and it is the default method. `measureText` will instead use a CanvasRenderingContext2D to measure the text in a particular node only if three conditions are met:

1. `renderSvg` is called from a browser, not from node.js.
2. A canvas element is passed in the second, optional argument to `renderSvg()`.
3. The node uses one of the following fonts: Helvetica, Arial, Times, or Times New Roman.

Helvetica and Arial are font-metric identical. Ditto Times and Times New Roman. They can be safely measured without worry that a user-agent will not have a matching system font.