### PR TITLE
Support SVG half ellipse

### DIFF
--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -74,9 +74,19 @@ skanaar.Svg = function (globalStyle){
 			elements.push(element)
 			return element
 		},
-		ellipse: function (center, w, h /*, start, stop*/){
-			return newElement('ellipse',
+		ellipse: function (center, w, h, start, stop){
+			if (stop) {
+				// This code does not render a general partial ellipse. It only
+				// renders the bottom half of an ellipse. Useful for database visuals.
+				var y = tY(center.y)
+				return newElement('path', { d:
+					'M' + tX(center.x - w/2) + ' ' + y +
+					'A' + w/2 + ' ' + h/2 + ' 0 1 0 ' + tX(center.x + w/2) + ' ' + y
+				})
+			} else {
+				return newElement('ellipse',
 				{ cx: tX(center.x), cy: tY(center.y), rx: w/2, ry: h/2 })
+			}
 		},
 		arc: function (x, y, r /*, start, stop*/){
 			return newElement('ellipse',


### PR DESCRIPTION
This PR modifies the `svg.ellipse()` method so that it can draw not only a full ellipse but also the bottom half of an ellipse. This corrects the rendering of a `<database>` node in SVG.