### PR TITLE
Set a dash array default

### DIFF
--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -1,6 +1,13 @@
 var skanaar = skanaar || {}
 skanaar.Svg = function (globalStyle){
-	var initialState = { x: 0, y: 0, stroke: 'none', fill: 'none', textAlign: 'left' }
+	var initialState = {
+		x: 0,
+		y: 0,
+		stroke: 'none',
+		dashArray: 'none',
+		fill: 'none',
+		textAlign: 'left'
+	}
 	var states = [initialState]
 	var elements = []
 


### PR DESCRIPTION
This is a follow up to PR #84. It adds a default `dashArray: 'none'` to the SVG `initialState`. Without the default, I found that some SVG paths were rendered with `stroke-dasharray:undefined`. With this PR, they get the proper specification, `stroke-dasharray:none`.