### PR TITLE
Improve SVG measureText

### DIFF
--- a/src/nomnoml.js
+++ b/src/nomnoml.js
@@ -80,10 +80,11 @@ var nomnoml = nomnoml || {};
 		return parseAndRender(code, skanaar.Canvas(canvas), canvas, scale || 1)
 	};
 
-	nomnoml.renderSvg = function (code) {
+	nomnoml.renderSvg = function (code, docCanvas) {
+		docCanvas = docCanvas || 0   // optional parameter
 		var ast = nomnoml.parse(code)
 		var config = getConfig(ast.directives)
-		var skCanvas = skanaar.Svg('')
+		var skCanvas = skanaar.Svg('', docCanvas)
 		function setFont(config, isBold, isItalic) {
 			var style = (isBold === 'bold' ? 'bold' : '')
 			if (isItalic) style = 'italic ' + style

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -150,7 +150,7 @@ nomnoml.render = function (graphics, config, compartment, setFont){
 		renderLabel(r.endLabel, end, adjustQuadrant(quadrant(end, endNode, 2), end, start))
 
 		if (r.assoc !== '-/-'){
-			if (g.setLineDash && skanaar.hasSubstring(r.assoc, '--')){
+			if (skanaar.hasSubstring(r.assoc, '--')){
 				var dash = Math.max(4, 2*config.lineWidth)
 				g.setLineDash([dash, dash])
 				strokePath(path)

--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -1,5 +1,5 @@
 var skanaar = skanaar || {}
-skanaar.Svg = function (globalStyle){
+skanaar.Svg = function (globalStyle, canvas){
 	var initialState = {
 		x: 0,
 		y: 0,

--- a/src/skanaar.svg.js
+++ b/src/skanaar.svg.js
@@ -11,7 +11,8 @@ skanaar.Svg = function (globalStyle){
 			attr: attr,
 			content: content || undefined,
 			stroke: function (){
-				this.attr.style += 'stroke:'+lastDefined('stroke')+';fill:none;';
+				this.attr.style += 'stroke:'+lastDefined('stroke')+
+				  ';fill:none;stroke-dasharray:' + lastDefined('dashArray') + ';';
 				return this
 			},
 			fill: function (){
@@ -19,7 +20,8 @@ skanaar.Svg = function (globalStyle){
 				return this
 			},
 			fillAndStroke: function (){
-				this.attr.style += 'stroke:'+lastDefined('stroke')+';fill:'+lastDefined('fill')+';';
+				this.attr.style += 'stroke:'+lastDefined('stroke')+';fill:'+lastDefined('fill')+
+				  ';stroke-dasharray:' + lastDefined('dashArray') + ';';
 				return this
 			}
 		}
@@ -146,7 +148,9 @@ skanaar.Svg = function (globalStyle){
 			states.push(State(0, 0))
 		},
 		scale: function (){},
-		setLineDash: function (){},
+		setLineDash: function (d){
+			last(states).dashArray = (d.length === 0) ? 'none' : d[0] + ' ' + d[1]
+		},
 		stroke: function (){
 			last(elements).stroke()
 		},

--- a/test/index.html
+++ b/test/index.html
@@ -53,6 +53,7 @@
   </script>
   <script id="sample_source" type="text/plain">
       #zoom: 0.5
+      #font: Arial
       [Pirate|
           [beard]--[parrot]
           [beard]-:>[foul mouth]
@@ -103,7 +104,8 @@
       function script(id){ return document.getElementById(id).innerHTML }
       nomnoml.draw(elem('canvas1'), script('sample_source'))
       nomnoml.draw(elem('canvas2'), script('label_test_source'))
-      elem('svg-host').innerHTML = nomnoml.renderSvg(script('sample_source'))
+      elem('svg-host').innerHTML = nomnoml.renderSvg(script('sample_source'),
+          document.createElement('canvas'))
   </script>
 
 </body>


### PR DESCRIPTION
This PR aims to improve SVG node sizing when possible, by improving the accuracy of the SVG `measureText` method.  The function `renderSvg(code, canvas)`  now has an optional parameter `canvas`.

The pre-existing `measureText` heuristic is still in place and it is the default method. `measureText` will instead use a CanvasRenderingContext2D to measure the text in a particular node only if three conditions are met:

1. `renderSvg` is called from a browser, not from node.js.
2. A canvas element is passed in the second, optional argument to `renderSvg()`.
3. The node uses one of the following fonts: Helvetica, Arial, Times, or Times New Roman.

Helvetica and Arial are font-metric identical. Ditto Times and Times New Roman. They can be safely measured without worry that a user-agent will not have a matching system font.