### PR TITLE
Prevent CommonJS exports in generated jison-parser.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ var jison = require('jison');
 var jshint = require('jshint').JSHINT;
 
 var nomnomlParser = new jison.Parser(fs.readFileSync('src/nomnoml.jison', { encoding: 'utf8' }));
-fs.writeFileSync('src/jison-parser.js', nomnomlParser.generate({moduleName: 'nomnomlCoreParser'}));
+fs.writeFileSync('src/jison-parser.js', nomnomlParser.generate({moduleName: 'nomnomlCoreParser',moduleType:'js'}));
 
 var nomnomlFiles = [
     'src/skanaar.canvas.js',

--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -1077,25 +1077,7 @@ function Parser () {
 }
 Parser.prototype = parser;parser.Parser = Parser;
 return new Parser;
-})();
-
-
-if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
-exports.parser = nomnomlCoreParser;
-exports.Parser = nomnomlCoreParser.Parser;
-exports.parse = function () { return nomnomlCoreParser.parse.apply(nomnomlCoreParser, arguments); };
-exports.main = function commonjsMain (args) {
-    if (!args[1]) {
-        console.log('Usage: '+args[0]+' FILE');
-        process.exit(1);
-    }
-    var source = require('fs').readFileSync(require('path').normalize(args[1]), "utf8");
-    return exports.parser.parse(source);
-};
-if (typeof module !== 'undefined' && require.main === module) {
-  exports.main(process.argv.slice(1));
-}
-};
+})();;
 var nomnoml = nomnoml || {}
 
 _.maxBy = _.maxBy || _.max // polyfill the differences between lodash and underscore

--- a/src/jison-parser.js
+++ b/src/jison-parser.js
@@ -616,21 +616,3 @@ function Parser () {
 Parser.prototype = parser;parser.Parser = Parser;
 return new Parser;
 })();
-
-
-if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
-exports.parser = nomnomlCoreParser;
-exports.Parser = nomnomlCoreParser.Parser;
-exports.parse = function () { return nomnomlCoreParser.parse.apply(nomnomlCoreParser, arguments); };
-exports.main = function commonjsMain (args) {
-    if (!args[1]) {
-        console.log('Usage: '+args[0]+' FILE');
-        process.exit(1);
-    }
-    var source = require('fs').readFileSync(require('path').normalize(args[1]), "utf8");
-    return exports.parser.parse(source);
-};
-if (typeof module !== 'undefined' && require.main === module) {
-  exports.main(process.argv.slice(1));
-}
-}


### PR DESCRIPTION
It can mess such bundler as webpack, which will try to load modules 
[dist/nomnoml.js#L1092](https://github.com/skanaar/nomnoml/compare/master...strobox:master#diff-2ffcfda022e4c4d199e7da4ac55aa2a0L1092)
 `var source = require('fs').readFileSync(require('path').normalize(args[1]), "utf8");`

which exists only in Node.js envirement, not in browser.