### PR TITLE
config: add acyclicer and ranker options to directives

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -70,7 +70,9 @@ var nomnoml;
                 rankdir: style.direction || config.direction,
                 nodesep: config.spacing,
                 edgesep: config.spacing,
-                ranksep: config.spacing
+                ranksep: config.spacing,
+                acyclicer: config.acyclicer,
+                ranker: config.ranker
             });
             c.nodes.forEach(function (e) {
                 g.setNode(e.name, { width: e.layoutWidth, height: e.layoutHeight });
@@ -278,6 +280,8 @@ var nomnoml;
                 stroke: d.stroke || '#33322E',
                 title: d.title || 'nomnoml',
                 zoom: +d.zoom || 1,
+                acyclicer: d.acyclicer,
+                ranker: d.ranker || 'network-simplex',
                 styles: nomnoml.skanaar.merged(nomnoml.styles, userStyles)
             };
         }

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -17,6 +17,8 @@ interface Config {
   arrowSize: number
   bendSize: number
   zoom: number
+  acyclicer?: 'greedy'
+  ranker: 'network-simplex' | 'tight-tree' | 'longest-path'
 }
 
 interface Measurer {

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -17,8 +17,8 @@ interface Config {
   arrowSize: number
   bendSize: number
   zoom: number
-  acyclicer?: 'greedy'
-  ranker: 'network-simplex' | 'tight-tree' | 'longest-path'
+  acyclicer?: string
+  ranker: string // 'network-simplex' | 'tight-tree' | 'longest-path'
 }
 
 interface Measurer {

--- a/src/layouter.ts
+++ b/src/layouter.ts
@@ -31,8 +31,8 @@ namespace nomnoml {
 				ranksep: config.spacing, //50 
 				//marginx: //0 
 				//marginy: //0 
-				//acyclicer: //undefined [greedy] 
-				//ranker: //network-simplex [network-simplex, tight-tree or longest-path]
+				acyclicer: config.acyclicer,
+				ranker: config.ranker //network-simplex [network-simplex, tight-tree or longest-path]
 			});
 			c.nodes.forEach(function (e){
 				g.setNode(e.name, { width: e.layoutWidth, height: e.layoutHeight })

--- a/src/layouter.ts
+++ b/src/layouter.ts
@@ -32,7 +32,7 @@ namespace nomnoml {
 				//marginx: //0 
 				//marginy: //0 
 				acyclicer: config.acyclicer,
-				ranker: config.ranker //network-simplex [network-simplex, tight-tree or longest-path]
+				ranker: config.ranker
 			});
 			c.nodes.forEach(function (e){
 				g.setNode(e.name, { width: e.layoutWidth, height: e.layoutHeight })

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -98,8 +98,8 @@ namespace nomnoml {
 				stroke: d.stroke || '#33322E',
 				title: d.title || 'nomnoml',
 				zoom: +d.zoom || 1,
-				acyclicer: d.acyclicer, // [greedy] | undefined
-				ranker: d.ranker || 'network-simplex',
+				acyclicer: d.acyclicer, // 'greedy' | undefined
+				ranker: d.ranker || 'network-simplex', // 'network-simplex' | 'tight-tree' | 'longest-path'
 				styles: skanaar.merged(nomnoml.styles, userStyles)
 			};
 		}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -98,7 +98,7 @@ namespace nomnoml {
 				stroke: d.stroke || '#33322E',
 				title: d.title || 'nomnoml',
 				zoom: +d.zoom || 1,
-				acyclicer: d.acyclicer,
+				acyclicer: d.acyclicer, // [greedy] | undefined
 				ranker: d.ranker || 'network-simplex',
 				styles: skanaar.merged(nomnoml.styles, userStyles)
 			};

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -98,6 +98,8 @@ namespace nomnoml {
 				stroke: d.stroke || '#33322E',
 				title: d.title || 'nomnoml',
 				zoom: +d.zoom || 1,
+				acyclicer: d.acyclicer,
+				ranker: d.ranker || 'network-simplex',
 				styles: skanaar.merged(nomnoml.styles, userStyles)
 			};
 		}


### PR DESCRIPTION
These options seem to affect my diagrams a lot, I know my use case might not be that common, but I thought it had no downsides, so I took the freedom and forked, here's the difference.

![img1](https://i.imgur.com/CxEDbpU.png)
![img2](https://i.imgur.com/kMAfyfc.png)

I still need to find where the documentation is, so I can update that too if you'd  like.
all we need to add to see those dramatic differences is:
```
#ranker: network-simplex
#acyclicer: greedy
```