### PR TITLE
Added typescript as a dev dep and fixed the webapp script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,12 @@
       "dev": true,
       "optional": true
     },
+    "typescript": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "aws-sdk": "^2.476.0",
     "jison": "0.4.13",
+    "typescript": "^3.6.3",
     "uglify-js": "^3.6.0"
   },
   "scripts": {
@@ -29,7 +30,7 @@
     "bundle": "node build/build.js",
     "test": "node test/test.js",
     "test_cli": "node dist/nomnoml-cli.js test/import-test.nomnoml test/output.node-test.svg",
-    "webapp": "node build/build-icons.js && ( cd webapp && tsc ) && uglifyjs dist/webapp.js -o dist/webapp.js"
+    "webapp": "node build/build-icons.js && ( cd webapp && tsc ) && cd .. && uglifyjs dist/webapp.js -o dist/webapp.js"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Ran into issues getting a local build working. Tracked it down to two issues:

1. `typescript` not installed as a dev dependency
1. the `webapp` script `cd`s into the `webapp` folder to run `tsc`, but then doesn't `cd..` back out to run the `uglify` step from the root. Fixed that. 