### PR TITLE
Embed source into SVG

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -193,7 +193,7 @@ var nomnoml;
         return skCanvas.serialize({
             width: layout.width,
             height: layout.height
-        });
+        }, code, config.title);
     }
     nomnoml.renderSvg = renderSvg;
 })(nomnoml || (nomnoml = {}));
@@ -699,6 +699,17 @@ var nomnoml;
         skanaar.Canvas = Canvas;
     })(skanaar = nomnoml.skanaar || (nomnoml.skanaar = {}));
 })(nomnoml || (nomnoml = {}));
+function escapeXml(unsafe) {
+    return unsafe.replace(/[<>&'"]/g, function (c) {
+        switch (c) {
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '&': return '&amp;';
+            case '\'': return '&apos;';
+            case '"': return '&quot;';
+        }
+    });
+}
 var nomnoml;
 (function (nomnoml) {
     var skanaar;
@@ -915,7 +926,7 @@ var nomnoml;
                     last(states).x += dx;
                     last(states).y += dy;
                 },
-                serialize: function (_attributes) {
+                serialize: function (_attributes, code, title) {
                     var attrs = _attributes || {};
                     attrs.version = attrs.version || '1.1';
                     attrs.baseProfile = attrs.baseProfile || 'full';
@@ -936,6 +947,12 @@ var nomnoml;
                         return '<' + e.name + ' ' + toAttr(e.attr) + '>' + (e.content || '') + '</' + e.name + '>';
                     }
                     var innerSvg = elements.map(toHtml).join('\n');
+                    if (code)
+                        innerSvg = toHtml(newElement('metadata', { content: code })) + innerSvg;
+                    if (code)
+                        innerSvg = toHtml(newElement('desc', {}, escapeXml(code))) + innerSvg;
+                    if (title)
+                        innerSvg = toHtml(newElement('title', {}, title)) + innerSvg;
                     return toHtml(Element('svg', attrs, innerSvg));
                 }
             };

--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -700,15 +700,7 @@ var nomnoml;
     })(skanaar = nomnoml.skanaar || (nomnoml.skanaar = {}));
 })(nomnoml || (nomnoml = {}));
 function escapeXml(unsafe) {
-    return unsafe.replace(/[<>&'"]/g, function (c) {
-        switch (c) {
-            case '<': return '&lt;';
-            case '>': return '&gt;';
-            case '&': return '&amp;';
-            case '\'': return '&apos;';
-            case '"': return '&quot;';
-        }
-    });
+    return unsafe.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 var nomnoml;
 (function (nomnoml) {
@@ -947,8 +939,6 @@ var nomnoml;
                         return '<' + e.name + ' ' + toAttr(e.attr) + '>' + (e.content || '') + '</' + e.name + '>';
                     }
                     var innerSvg = elements.map(toHtml).join('\n');
-                    if (code)
-                        innerSvg = toHtml(newElement('metadata', { content: code })) + innerSvg;
                     if (code)
                         innerSvg = toHtml(newElement('desc', {}, escapeXml(code))) + innerSvg;
                     if (title)

--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@
 
 	<script>
 		var handleSVG = (files)=>{
-			if(files.length !== 1) return alert('Only upload a single SVG.');
+			if(files.length !== 1) return alert('Only upload a single file.');
 			reader = new FileReader();
 			reader.onload = ()=>{
 				if(!app.loadSVG(reader.result)) alert("SVG did not have nomnoml code embedded within it.");
@@ -523,6 +523,16 @@
 		FileMenu('[file-menu]', app)
 		StorageTools('.storage-tools', app)
 		metrics.track('visit', { files: app.filesystem.files().length })
+
+
+		app.editor.on('drop', (cm,dragEvent)=>{
+			var files = dragEvent.dataTransfer.files;
+			if(files.length !== 1) return alert('Only upload a single file.')
+			if(files[0].type == "image/svg+xml"){
+				dragEvent.preventDefault();
+				handleSVG(files);
+			}
+		})
 	</script>
 
 	<script>

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
 					</a>
 
 					<a class="btn" href="/" v-on:click.prevent="downloadSvg">
-						<icon id=image-outline></icon> Download SVG
+						<icon id=image-outline></icon> Download SVG with source
 					</a>
 
 					<a class="btn" href="/" v-on:click.prevent="downloadSrc">
@@ -277,7 +277,7 @@
 						<icon id=document-add></icon> Save to local file...
 					</a>
 
-					<a class="btn" href="/">
+					<a class="btn">
 						<icon id=image-outline></icon> Load an SVG...
 						<input type="file" accept="image/svg+xml" onchange="handleSVG(this.files)">
 					</a>

--- a/index.html
+++ b/index.html
@@ -524,7 +524,6 @@
 		StorageTools('.storage-tools', app)
 		metrics.track('visit', { files: app.filesystem.files().length })
 
-
 		app.editor.on('drop', (cm,dragEvent)=>{
 			var files = dragEvent.dataTransfer.files;
 			if(files.length !== 1) return alert('Only upload a single file.')

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
 				visual=sender<br>
 				visual=start<br>
 				visual=transceiver
-				
+
 				<label>Available modifiers are</label>
 
 				bold<br>
@@ -277,6 +277,11 @@
 						<icon id=document-add></icon> Save to local file...
 					</a>
 
+					<a class="btn" href="/">
+						<icon id=image-outline></icon> Load an SVG...
+						<input type="file" accept="image/svg+xml" onchange="handleSVG(this.files)">
+					</a>
+
 					<hr/>
 
 					<h2>Local files</h2>
@@ -333,7 +338,7 @@
 			</a>
 
 			<div id="tooltip"></div>
-			
+
 			<div class="storage-tools">
 				<span class="storage-status" v-bind:class="{ visible: isUrlStorage() }">
 					View mode, changes are not saved.
@@ -341,7 +346,7 @@
 					   title="Save this diagram to localStorage">save</a>
 					<a href="#" title="Discard this diagram">close</a>
 				</span>
-				
+
 				<span class="storage-status" v-bind:class="{ visible: isLocalFileStorage() }">
 					Editing local file
 					<a href="#" title="Exit from this file">close</a>
@@ -497,19 +502,29 @@
 	<script src="codemirror/codemirror-compressed.js"></script>
 	<script src="codemirror/nomnoml.codemirror-mode.js"></script>
 	<script src="dist/nomnoml.web.js"></script>
-	
+
 	<script src="lib/vue.min.js"></script>
 	<script src="dist/webapp.js"></script>
-	
+
 	<script>
+		var handleSVG = (files)=>{
+			if(files.length !== 1) return alert('Only upload a single SVG.');
+			reader = new FileReader();
+			reader.onload = ()=>{
+				if(!app.loadSVG(reader.result)) alert("SVG did not have nomnoml code embedded within it.");
+			};
+			reader.readAsText(files[0]);
+		}
+
 		var metrics = isNomnomlDomain ? mixpanel : { track: console.log.bind(console) }
 		var app = new App(nomnoml, CodeMirror, metrics, saveAs, _.throttle, _.debounce)
+
 		ExportMenu('[export-menu]', app)
 		FileMenu('[file-menu]', app)
 		StorageTools('.storage-tools', app)
 		metrics.track('visit', { files: app.filesystem.files().length })
 	</script>
-	
+
 	<script>
 		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/src/nomnoml.ts
+++ b/src/nomnoml.ts
@@ -57,9 +57,7 @@ namespace nomnoml {
 
   export function renderSvg(code: string, docCanvas?: HTMLCanvasElement): string {
     var parsedDiagram = parse(code)
-    //console.log(parsedDiagram);
     var config = parsedDiagram.config
-    //console.log(config);
     var skCanvas = skanaar.Svg('', docCanvas)
     function setFont(config: Config, isBold: 'bold'|'normal', isItalic: 'italic'|undefined) {
       var style = (isBold === 'bold' ? 'bold' : '')

--- a/src/nomnoml.ts
+++ b/src/nomnoml.ts
@@ -57,7 +57,9 @@ namespace nomnoml {
 
   export function renderSvg(code: string, docCanvas?: HTMLCanvasElement): string {
     var parsedDiagram = parse(code)
+    //console.log(parsedDiagram);
     var config = parsedDiagram.config
+    //console.log(config);
     var skCanvas = skanaar.Svg('', docCanvas)
     function setFont(config: Config, isBold: 'bold'|'normal', isItalic: 'italic'|undefined) {
       var style = (isBold === 'bold' ? 'bold' : '')
@@ -75,11 +77,11 @@ namespace nomnoml {
       textHeight: function (): number { return config.leading * config.fontSize }
     };
     var layout = nomnoml.layout(measurer, config, parsedDiagram.root)
-    
+
     nomnoml.render(skCanvas, config, layout, measurer.setFont)
     return skCanvas.serialize({
       width: layout.width,
       height: layout.height
-    })
+    }, code, config.title)
   }
 }

--- a/src/skanaar.svg.ts
+++ b/src/skanaar.svg.ts
@@ -1,16 +1,3 @@
-function escapeXml(unsafe: string) {
-    return unsafe.replace(/[<>&'"]/g, function (c) {
-        switch (c) {
-            case '<': return '&lt;';
-            case '>': return '&gt;';
-            case '&': return '&amp;';
-            case '\'': return '&apos;';
-            case '"': return '&quot;';
-        }
-    });
-}
-
-
 namespace nomnoml.skanaar {
 
 	interface SvgState {
@@ -272,8 +259,10 @@ namespace nomnoml.skanaar {
 				}
 				var innerSvg = elements.map(toHtml).join('\n')
 
-				//if(code) innerSvg = toHtml(newElement('metadata', {content: code})) + innerSvg;
-				if(code) innerSvg = toHtml(newElement('desc', {}, escapeXml(code))) + innerSvg;
+				if(code){
+					code = code.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					innerSvg = toHtml(newElement('desc', {}, code)) + innerSvg;
+				}
 				if(title) innerSvg = toHtml(newElement('title', {}, title)) + innerSvg;
 				return toHtml(Element('svg', attrs, innerSvg))
 			}

--- a/src/skanaar.svg.ts
+++ b/src/skanaar.svg.ts
@@ -1,3 +1,16 @@
+function escapeXml(unsafe: string) {
+    return unsafe.replace(/[<>&'"]/g, function (c) {
+        switch (c) {
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '&': return '&amp;';
+            case '\'': return '&apos;';
+            case '"': return '&quot;';
+        }
+    });
+}
+
+
 namespace nomnoml.skanaar {
 
 	interface SvgState {
@@ -11,7 +24,7 @@ namespace nomnoml.skanaar {
 	}
 
 	interface SvgGraphics extends Graphics {
-		serialize(_attributes: any): string
+		serialize(_attributes: any, code: string, title: string): string
 	}
 
   export function Svg(globalStyle: string, canvas?: HTMLCanvasElement): SvgGraphics {
@@ -211,7 +224,7 @@ namespace nomnoml.skanaar {
 							if (c === 'M' || c === 'W') { return 14 }
 							return c.charCodeAt(0) < 200 ? 9.5 : 16
 						})
-					}	
+					}
 				}
 			},
 			moveTo: function (x, y){
@@ -237,7 +250,7 @@ namespace nomnoml.skanaar {
 				last(states).x += dx
 				last(states).y += dy
 			},
-			serialize: function (_attributes: any): string {
+			serialize: function (_attributes: any, code: string, title: string): string {
 				var attrs = _attributes || {};
 				attrs.version = attrs.version || '1.1';
 				attrs.baseProfile = attrs.baseProfile || 'full';
@@ -258,6 +271,10 @@ namespace nomnoml.skanaar {
 					return '<'+e.name+' '+toAttr(e.attr)+'>'+(e.content || '')+'</'+e.name+'>'
 				}
 				var innerSvg = elements.map(toHtml).join('\n')
+
+				//if(code) innerSvg = toHtml(newElement('metadata', {content: code})) + innerSvg;
+				if(code) innerSvg = toHtml(newElement('desc', {}, escapeXml(code))) + innerSvg;
+				if(title) innerSvg = toHtml(newElement('title', {}, title)) + innerSvg;
 				return toHtml(Element('svg', attrs, innerSvg))
 			}
 		}

--- a/test/import-test.nomnoml
+++ b/test/import-test.nomnoml
@@ -1,3 +1,4 @@
+#title: import-test
 #direction: right
 #import: box.style.nomnoml
 

--- a/webapp/App.ts
+++ b/webapp/App.ts
@@ -3,6 +3,7 @@ class App {
   filesystem: FileSystem
   defaultSource: string
   editor: CodeMirrorEditor
+  loadSVG: (svg: string) => boolean
   sourceChanged: () => void
   downloader: DownloadLinks
   signals: Observable = Observable({})
@@ -88,6 +89,15 @@ class App {
       }
     }
 
+    this.loadSVG = (svg) => {
+      var svgNodes = (new DOMParser()).parseFromString(svg,"text/xml");
+      if(svgNodes.getElementsByTagName('desc').length !== 1) return false;
+      var code = svgNodes.getElementsByTagName('desc')[0].childNodes[0].nodeValue;
+      code = code.replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+      this.editor.setValue(code);
+      return true;
+    }
+
     reloadStorage()
   }
 
@@ -127,7 +137,7 @@ class App {
 
   saveViewModeToStorage(){
     this.metrics.track('view_mode_save:query')
-    var question = 
+    var question =
       'Do you want to overwrite the diagram in ' +
       'localStorage with the currently viewed diagram?'
     if (confirm(question)){


### PR DESCRIPTION
The goal of this PR is to enable the ability to store the nomnoml code within a generated SVG. 

- Embed the escaped source into the `<desc>` tag of the generated SVG
- Add an upload SVG button onto the Webapp and parse out the embedded source
- Enable drag-and-drop onto the editor to easily upload SVGs

The code can probably be moved around into better places, but it's working.