### PR TITLE
Combine npm scripts and fix minify error when first build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "uglify-js": "^3.6.0"
   },
   "scripts": {
-    "prepare": "npm run compile && npm run bundle && npm run test && npm run test_cli && npm run minify && npm run webapp",
-    "minify": "uglifyjs dist/nomnoml.web.js -o dist/nomnoml.web.js",
-    "build": "cd src && tsc && npm run bundle",
-    "compile": "cd src && tsc",
+    "prepare": "npm run build && npm run test && npm run test_cli && npm run webapp && npm run minify",
+    "minify": "uglifyjs dist/nomnoml.web.js -o dist/nomnoml.web.js && uglifyjs dist/webapp.js -o dist/webapp.js",
+    "build": "npm run compile && npm run bundle",
+    "compile": "tsc --build src/tsconfig.json",
     "bundle": "node build/build.js",
     "test": "node test/test.js",
     "test_cli": "node dist/nomnoml-cli.js test/import-test.nomnoml test/output.node-test.svg",
-    "webapp": "node build/build-icons.js && ( cd webapp && tsc ) && cd .. && uglifyjs dist/webapp.js -o dist/webapp.js"
+    "webapp": "node build/build-icons.js && tsc --build webapp/tsconfig.json"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Remove duplicate npm scripts, use tsc --build instruction to specify project to build and fix the error(cannot find dist/webapp.js file) when execute webapp script.