### PR TITLE
fix: fix typo in the og:description

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.nomnoml.com">
 <meta property="og:title" content="Nomnoml">
-<meta property="og:description" content="A tool for drawing diagrams based on syntax. Supercharge you boxes and arrows.">
+<meta property="og:description" content="A tool for drawing diagrams based on syntax. Supercharge your boxes and arrows.">
 <meta property="og:image" content="https://www.nomnoml.com/img/example.png">
 </head>
 <body>


### PR DESCRIPTION
This PR fixes a tiny typo in the `og:description` (supercharge you -> supercharge your) so that people don't need to point it out when the link is shared 👁️ 