### PR TITLE
fix off by 1 error

### DIFF
--- a/src/nomnoml.ts
+++ b/src/nomnoml.ts
@@ -142,7 +142,7 @@ export function compileFile(filepath: string, maxImportDepth?: number): string {
   var path = require('path')
 
   var directory = path.dirname(filepath)
-  var rootFileName = filepath.substr(directory.length)
+  var rootFileName = filepath.substr(directory.length - 1)
 
   function loadFile(filename: string): string {
     return fs.readFileSync(path.join(directory, filename), { encoding: 'utf8' })


### PR DESCRIPTION
Hi and thanks for this great library :)

While playing around with it and creating awesome diagrams

https://forums.civfanatics.com/media/realism-invictus-3-6-tech-tree-flowchart-eras.7107/full

and

https://forums.civfanatics.com/media/realism-invictus-3-6-tech-tree-flowchart.7106/full

I stumbled upon a bug for https://github.com/skanaar/nomnoml#command-line-interface

```
npx nomnoml input-file.noml
```

omits first filename char and program crashes for me.

Here's my proposed fix and have a nice week
midzer