### PR TITLE
Use path.basename to get the correct filename

### DIFF
--- a/dist/nomnoml.js
+++ b/dist/nomnoml.js
@@ -1788,7 +1788,7 @@
         const fs = require('fs');
         const path = require('path');
         const directory = path.dirname(filepath);
-        const rootFileName = filepath.substr(directory.length);
+        const rootFileName = path.basename(filepath);
         function loadFile(filename) {
             return fs.readFileSync(path.join(directory, filename), { encoding: 'utf8' });
         }

--- a/src/nomnoml.ts
+++ b/src/nomnoml.ts
@@ -142,7 +142,7 @@ export function compileFile(filepath: string, maxImportDepth?: number): string {
   const path = require('path')
 
   const directory = path.dirname(filepath)
-  const rootFileName = filepath.substr(directory.length)
+  const rootFileName = path.basename(filepath)
 
   function loadFile(filename: string): string {
     return fs.readFileSync(path.join(directory, filename), { encoding: 'utf8' })


### PR DESCRIPTION
I took the advice of @kc97ble, and used `path.basename` to get the correct filename.  You should be able to close all of the following after accepting this.

## Relevant issues and PRs:
- #164 
- #217 
- #222 
